### PR TITLE
Adjust Light/Dark themes

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -40,6 +40,17 @@
   background-color: #2d2d2d;
 }
 
+[data-theme='dark'] .navbar {
+  background-color: #2d2d2d;
+  border-bottom: 1px solid #7a8386;
+}
+
+.subtitleWrapper {
+  margin-left: 16px;
+  font-weight: 500;
+  color: #7a8386;
+}
+
 .docusaurus-highlight-code-line {
   background-color: rgba(0, 0, 0, 0.1);
   display: block;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -28,6 +28,14 @@
   --ifm-color-primary-lightest: #4fddbf;
 }
 
+[data-theme='dark'] .menu {
+  background-color: #1e1e1e;
+}
+
+[data-theme='light'] .menu {
+  background-color: #faf9f8;
+}
+
 .docusaurus-highlight-code-line {
   background-color: rgba(0, 0, 0, 0.1);
   display: block;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -36,6 +36,10 @@
   background-color: #faf9f8;
 }
 
+[data-theme='dark'] .docs-doc-page {
+  background-color: #2d2d2d;
+}
+
 .docusaurus-highlight-code-line {
   background-color: rgba(0, 0, 0, 0.1);
   display: block;

--- a/src/theme/Logo/index.js
+++ b/src/theme/Logo/index.js
@@ -73,7 +73,7 @@ export default function Logo(props) {
               stroke="#B4B9BB"
             />
           </svg>
-          <h3 className={classes.subtitleWrapper}>Developer Docs</h3>
+          <h3 className="subtitleWrapper">Developer Docs</h3>
         </div>
       )}
     </>

--- a/src/theme/Logo/style.module.css
+++ b/src/theme/Logo/style.module.css
@@ -2,8 +2,3 @@
   display: flex;
   align-items: flex-end;
 }
-
-.subtitleWrapper {
-  margin-left: 16px;
-  font-weight: 500;
-}

--- a/src/theme/Toggle/styles.module.css
+++ b/src/theme/Toggle/styles.module.css
@@ -6,8 +6,8 @@
  */
 
 .customToggleStyle {
-  border: none;
   background-color: inherit;
+  border: none;
   cursor: pointer;
 }
 


### PR DESCRIPTION
:zap: _Don't forget to link the Shortcut ticket ID in the branch name!_

## What Changes

- Before this PR, backgrounds where either only stark white or black. Now, there are two gradients of each color (compare left nav to body & header).
<img width="1275" alt="Screen Shot 2022-03-03 at 1 48 37 PM" src="https://user-images.githubusercontent.com/67024033/156641646-b1f6f66c-699b-4b7e-a136-e2a8a8dde788.png">
<img width="1180" alt="Screen Shot 2022-03-03 at 1 48 56 PM" src="https://user-images.githubusercontent.com/67024033/156641678-e4d6e2ac-e65c-4691-a6d4-43339376581d.png">

