### PR TITLE
Add docs for the graph

### DIFF
--- a/docs/ethereum/the-graph.mdx
+++ b/docs/ethereum/the-graph.mdx
@@ -8,7 +8,7 @@ A hosted [The Graph](https://thegraph.com/en/) node is available to use on Kava 
 - JSON-RPC Admin (Deploy subgraphs): https://the-graph-admin.kava.io
 - GraphQL HTTP Server (Query subgraphs): https://the-graph.kava.io
 
-An example deployed subgraph is available for [V2 Uniswap](http://example.com).
+[An example deployed subgraph](https://the-graph.evm-alpha.kava.io/subgraphs/name/Kava-Labs/v2-uniswap/graphql) is available for V2 Uniswap on Kava EVM Testnet.
 
 # Deploying Subgraphs
 
@@ -30,13 +30,13 @@ The network name for Kava EVM is `kava-evm`.
 ### Create your subgraph
 
 ```bash
-graph create <subgraph-name> --node https://the-graph-admin.evm-alpha.kava.io
+graph create <subgraph-name> --node https://the-graph-admin.kava.io
 ```
 
 ### Deploy your subgraph
 
 ```bash
-graph deploy <subgraph-name> --debug --ipfs https://api.thegraph.com/ipfs/ --node graph deploy Kava-Labs/v2-uniswap --debug --ipfs https://api.thegraph.com/ipfs/ --node http://127.0.0.1:8020
+graph deploy <subgraph-name> --debug --ipfs https://api.thegraph.com/ipfs/ --node https://the-graph-admin.kava.io
 ```
 
 Note that you can either use your own ipfs node here or `https://api.thegraph.com/ipfs/`.

--- a/docs/ethereum/the-graph.mdx
+++ b/docs/ethereum/the-graph.mdx
@@ -1,0 +1,44 @@
+---
+sidebar_position: 4
+title: The Graph
+---
+
+A hosted [The Graph](https://thegraph.com/en/) node is available to use on Kava EVM.
+
+- JSON-RPC Admin (Deploy subgraphs): https://the-graph-admin.kava.io
+- GraphQL HTTP Server (Query subgraphs): https://the-graph.kava.io
+
+An example deployed subgraph is available for [V2 Uniswap](http://example.com).
+
+# Deploying Subgraphs
+
+### Install graph-cli
+
+https://github.com/graphprotocol/graph-cli#installation
+
+### Write your subgraph
+
+See https://thegraph.com/docs/en/developer/create-subgraph-hosted/.
+
+You can also use an example project like [v2-uniswap](https://github.com/Uniswap/v2-subgraph).
+
+### Upgrade the manifest
+
+Update the `network` properties in the `subgraph.yaml` manifest file.
+The network name for Kava EVM is `kava-evm`.
+
+### Create your subgraph
+
+```bash
+graph create <subgraph-name> --node https://the-graph-admin.evm-alpha.kava.io
+```
+
+### Deploy your subgraph
+
+```bash
+graph deploy <subgraph-name> --debug --ipfs https://api.thegraph.com/ipfs/ --node graph deploy Kava-Labs/v2-uniswap --debug --ipfs https://api.thegraph.com/ipfs/ --node http://127.0.0.1:8020
+```
+
+Note that you can either use your own ipfs node here or `https://api.thegraph.com/ipfs/`.
+
+Once deployed, your graph should now be deployed and accessible via the GraphQL Server. It can be access at `https://the-graph.kava.io/subgraphs/name/<subgraph-name>/graphql`.


### PR DESCRIPTION
:zap: _Don't forget to link the Shortcut ticket ID in the branch name!_

## What Changes

- Docs for using The Graph on Kava EVM 
- Placeholder for v2 uniswap subgraph since we have not deployed it yet. Shouldn't be merged until we have that ready.
- Endpoints for the graph is not yet available but should be the ones we will be using.


## TODOs before merge ready
- [x] Deploy the graph on mainnet and make sure all mainnet graph urls are correct
- [ ] Deploy uniswap v2 subgraph on mainnet