### PR TITLE
add page about accessing historic kava data

### DIFF
--- a/docs/participate/faq/historic-data.mdx
+++ b/docs/participate/faq/historic-data.mdx
@@ -1,0 +1,17 @@
+# Accessing Historic Kava Data
+
+Kava Labs runs free, public archive nodes of all historic Kava versions.
+These endpoints are documented below with the relevant time frames for the data they contain:
+
+| Major Version | Kava Version | Chain ID     | Final Block Height | Start Date | End Date   | Archive Endpoints                                                                                                        |
+| ------------- | ------------ | ------------ | ------------------ | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Kava 2        | v0.3.5       | kava-2       | 2598890            | 2019-11-15 | 2020-06-10 | [API](https://api.kava-2.archives.kava.io/node_info)<br/>[RPC](https://rpc.kava-2.archives.kava.io/status)               |
+| Kava 3        | v0.10.0      | kava-3       | 1552962            | 2020-06-10 | 2020-10-15 | [API](https://api.kava-3.archives.kava.io/node_info)<br/>[RPC](https://rpc.kava-3.archives.kava.io/status)               |
+| Kava 4        | v0.12.2      | kava-4       | 1267330            | 2020-10-15 | 2021-03-04 | [API](https://api.kava-4.archives.kava.io/node_info)<br/>[RPC](https://rpc.kava-4.archives.kava.io/status)               |
+| Kava 6        | v0.12.4      | kava-6       | 334944             | 2021-03-05 | 2021-04-08 | [API](https://api.kava-6.archives.kava.io/node_info)<br/>[RPC](https://rpc.kava-6.archives.kava.io/status)               |
+| Kava 7        | v0.14.2      | kava-7       | 1878508            | 2021-04-08 | 2021-08-30 | [API](https://api.kava-7.archives.kava.io/node_info)<br/>[RPC](https://rpc.kava-7.archives.kava.io/status)               |
+| Kava 8        | v0.15.2      | kava-8       | 1803249            | 2021-08-31 | 2022-01-19 | [API](https://api.kava-8.archives.kava.io/node_info)<br/>[RPC](https://rpc.kava-8.archives.kava.io/status)               |
+| Kava 9        | v0.16.1      | kava-9       | 1610470            | 2022-01-19 | 2022-05-25 | [API](https://api.kava-9.archives.kava.io/node_info)<br/>[RPC](https://rpc.kava-9.archives.kava.io/status)               |
+| Kava 10       | v0.18.0      | kava_2222-10 |                    | 2022-05-25 | present    | [API](https://api.data.kava.io/node_info)<br/>[RPC](https://rpc.data.kava.io/status)<br/>[EVM](https://evm.data.kava.io) |
+
+Note that the Kava 5 upgrade was reverted. Those data are also available: [API](https://api.kava-5.archives.kava.io/node_info) & [RPC](https://rpc.kava-5.archives.kava.io/status)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5692,13 +5692,19 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001312",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
-      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "version": "1.0.30001412",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001412.tgz",
+      "integrity": "sha512-+TeEIee1gS5bYOiuf+PS/kp2mrXic37Hl66VY6EAfxasIk5fELTktK2oOezYed12H8w7jt3s512PpulQidPjwA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/ccount": {
       "version": "1.1.0",
@@ -19487,9 +19493,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001312",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
-      "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ=="
+      "version": "1.0.30001412",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001412.tgz",
+      "integrity": "sha512-+TeEIee1gS5bYOiuf+PS/kp2mrXic37Hl66VY6EAfxasIk5fELTktK2oOezYed12H8w7jt3s512PpulQidPjwA=="
     },
     "ccount": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
     "@material-ui/core": "^4.12.3",
     "@mdx-js/react": "^1.6.22",
     "@mui/material": "^5.4.4",
+    "bech32": "^1.1.3",
     "clsx": "^1.1.1",
+    "ethers": "^5.6.2",
     "font-face": "^2.3.4",
     "prism-react-renderer": "^1.2.1",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1",
-    "ethers": "^5.6.2",
-    "bech32": "^1.1.3"
+    "react-dom": "^17.0.1"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^2.0.0-beta.16",


### PR DESCRIPTION
## What Changes

- Adds details on endpoints of historic kava version archive nodes

## Why

Sometimes users need to access the data from previous Kava versions. Kava Labs has public endpoints for querying these data available at the listed endpoints!
