### PR TITLE
docs: update with kava 13 & v0.23.0 info

### DIFF
--- a/docs/cosmos/getting-started.mdx
+++ b/docs/cosmos/getting-started.mdx
@@ -8,7 +8,7 @@ This document will help you get a kava network up and running locally on your ma
 
 You must have the following tools:
 
-1. [Go 1.18](https://golang.org/doc/install) - used to build & install `kvtool`
+1. [Go 1.20](https://golang.org/doc/install) - used to build & install `kvtool`
 2. [Docker](https://docs.docker.com/get-docker/) - used by `kvtool` to run local networks.
 
 ## Ensure Go is setup in your PATH

--- a/docs/participate/faq/historic-data.mdx
+++ b/docs/participate/faq/historic-data.mdx
@@ -3,21 +3,27 @@
 Kava Labs runs free, public archive nodes of all historic Kava versions.
 These endpoints are documented below with the relevant time frames for the data they contain:
 
-| Major Version | Kava Version | Chain ID     | Final Block Height | Start Date | End Date   | Archive Endpoints                                                                                                        |
-| ------------- | ------------ | ------------ | ------------------ | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------ |
-| Kava 2        | v0.3.5       | kava-2       | 2598890            | 2019-11-15 | 2020-06-10 | [API](https://api.kava-2.archives.kava.io/node_info)<br/>[RPC](https://rpc.kava-2.archives.kava.io/status)               |
-| Kava 3        | v0.10.0      | kava-3       | 1552962            | 2020-06-10 | 2020-10-15 | [API](https://api.kava-3.archives.kava.io/node_info)<br/>[RPC](https://rpc.kava-3.archives.kava.io/status)               |
-| Kava 4        | v0.12.2      | kava-4       | 1267330            | 2020-10-15 | 2021-03-04 | [API](https://api.kava-4.archives.kava.io/node_info)<br/>[RPC](https://rpc.kava-4.archives.kava.io/status)               |
-| Kava 6        | v0.12.4      | kava-6       | 334944             | 2021-03-05 | 2021-04-08 | [API](https://api.kava-6.archives.kava.io/node_info)<br/>[RPC](https://rpc.kava-6.archives.kava.io/status)               |
-| Kava 7        | v0.14.2      | kava-7       | 1878508            | 2021-04-08 | 2021-08-30 | [API](https://api.kava-7.archives.kava.io/node_info)<br/>[RPC](https://rpc.kava-7.archives.kava.io/status)               |
-| Kava 8        | v0.15.2      | kava-8       | 1803249            | 2021-08-31 | 2022-01-19 | [API](https://api.kava-8.archives.kava.io/node_info)<br/>[RPC](https://rpc.kava-8.archives.kava.io/status)               |
-| Kava 9        | v0.16.1      | kava-9       | 1610470            | 2022-01-19 | 2022-05-25 | [API](https://api.kava-9.archives.kava.io/node_info)<br/>[RPC](https://rpc.kava-9.archives.kava.io/status)               |
-| Kava 10       | v0.18.2      | kava_2222-10 | 2098400            | 2022-05-25 | 2022-10-26 | [API](https://api.data.kava.io/node_info)<br/>[RPC](https://rpc.data.kava.io/status)<br/>[EVM](https://evm.data.kava.io) |
-| Kava 11       | v0.19.2      | kava_2222-10 |                    | 2022-10-26 | present    | [API](https://api.data.kava.io/node_info)<br/>[RPC](https://rpc.data.kava.io/status)<br/>[EVM](https://evm.data.kava.io) |
+| Major Version | Kava Version | Chain ID     | Final Block Height   | Start Date | End Date   | Archive Endpoints                                                                                                        |
+| ------------- | ------------ | ------------ | -------------------- | ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Kava 2        | v0.3.5       | kava-2       | 2598890<sup>\*</sup> | 2019-11-15 | 2020-06-10 | [API](https://api.kava-2.archives.kava.io/node_info)<br/>[RPC](https://rpc.kava-2.archives.kava.io/status)               |
+| Kava 3        | v0.10.0      | kava-3       | 1552962<sup>\*</sup> | 2020-06-10 | 2020-10-15 | [API](https://api.kava-3.archives.kava.io/node_info)<br/>[RPC](https://rpc.kava-3.archives.kava.io/status)               |
+| Kava 4        | v0.12.2      | kava-4       | 1267330<sup>\*</sup> | 2020-10-15 | 2021-03-04 | [API](https://api.kava-4.archives.kava.io/node_info)<br/>[RPC](https://rpc.kava-4.archives.kava.io/status)               |
+| Kava 6        | v0.12.4      | kava-6       | 334944<sup>\*</sup>  | 2021-03-05 | 2021-04-08 | [API](https://api.kava-6.archives.kava.io/node_info)<br/>[RPC](https://rpc.kava-6.archives.kava.io/status)               |
+| Kava 7        | v0.14.2      | kava-7       | 1878508<sup>\*</sup> | 2021-04-08 | 2021-08-30 | [API](https://api.kava-7.archives.kava.io/node_info)<br/>[RPC](https://rpc.kava-7.archives.kava.io/status)               |
+| Kava 8        | v0.15.2      | kava-8       | 1803249<sup>\*</sup> | 2021-08-31 | 2022-01-19 | [API](https://api.kava-8.archives.kava.io/node_info)<br/>[RPC](https://rpc.kava-8.archives.kava.io/status)               |
+| Kava 9        | v0.16.1      | kava-9       | 1610470<sup>\*</sup> | 2022-01-19 | 2022-05-25 | [API](https://api.kava-9.archives.kava.io/node_info)<br/>[RPC](https://rpc.kava-9.archives.kava.io/status)               |
+| Kava 10       | v0.18.2      | kava_2222-10 | 2098400              | 2022-05-25 | 2022-10-26 | [API](https://api.data.kava.io/node_info)<br/>[RPC](https://rpc.data.kava.io/status)<br/>[EVM](https://evm.data.kava.io) |
+| Kava 11       | v0.19.2      | kava_2222-10 | 3607200              | 2022-10-26 | 2023-02-26 | [API](https://api.data.kava.io/node_info)<br/>[RPC](https://rpc.data.kava.io/status)<br/>[EVM](https://evm.data.kava.io) |
+| Kava 12       | v0.21.1      | kava_2222-10 | 4832500              | 2023-02-26 | 2023-05-17 | [API](https://api.data.kava.io/node_info)<br/>[RPC](https://rpc.data.kava.io/status)<br/>[EVM](https://evm.data.kava.io) |
+| Kava 13       | v0.23.0      | kava_2222-10 |                      | 2023-05-17 | present    | [API](https://api.data.kava.io/node_info)<br/>[RPC](https://rpc.data.kava.io/status)<br/>[EVM](https://evm.data.kava.io) |
+
+<sup>*</sup> <i>block height was reset to 0 after these upgrades</i>
+<br />
+<br />
 
 As of the Kava 10 release, all upgrades are done as in-place software upgrades.
 The chain id no longer updates and the block height is never reset to 0, as was the case with all
 upgrades prior to Kava 10. Historical data for all upgrades since Kava 10 are available on the
-mainnet data node endpoints.
+mainnet data node endpoints. Some data may need to be queried with the historic verison of the Kava CLI.
 
 Note that the Kava 5 upgrade was reverted. Those data are also available: [API](https://api.kava-5.archives.kava.io/node_info) & [RPC](https://rpc.kava-5.archives.kava.io/status)

--- a/docs/participate/validator-node.mdx
+++ b/docs/participate/validator-node.mdx
@@ -37,8 +37,8 @@ sudo apt install build-essential jq -y
 sudo apt install git
 
 # Install go
-wget https://dl.google.com/go/go1.18.1.linux-amd64.tar.gz (or latest version at https://golang.org/dl/)
-sudo tar -xvf go1.18.1.linux-amd64.tar.gz
+wget https://dl.google.com/go/go1.20.linux-amd64.tar.gz (or latest version at https://golang.org/dl/)
+sudo tar -xvf go1.20.linux-amd64.tar.gz
 sudo mv go /usr/local
 
 # Updates environmental variables to include go
@@ -55,17 +55,17 @@ To verify that Go is installed:
 
 ```bash
 go version
-# Should return go version go1.18.1 linux/amd64
+# Should return go version go1.20 linux/amd64
 ```
 
 ## Install Kava
 
-Install Kava using `git clone`. Note that version 0.21.0 is the correct version for mainnet.
+Install Kava using `git clone`. Note that version 0.23.0 is the correct version for mainnet.
 
 ```bash
 git clone https://github.com/kava-labs/kava
 cd kava
-git checkout v0.21.0
+git checkout v0.23.0
 make install
 ```
 
@@ -73,12 +73,13 @@ To verify that kava is installed:
 
 ```bash
 kava version --long
+# build_tags: netgo,ledger
+# commit: 1fed82f3c5c054900c4a992ad3be47c63f332d96
+# cosmos_sdk_version: v0.46.11
+# go: go version go1.20 darwin/arm64
 # name: kava
 # server_name: kava
-# version: 0.21.0
-# commit: 357ec96338a4c4fa4624560f1182bf85cc068009
-# build_tags: netgo,ledger
-# go: go version go1.18.1 darwin/amd64
+# version: 0.23.0
 ```
 
 ## Configuring Your Node
@@ -87,7 +88,7 @@ Next, download the correct version of the kava node data and sync a node:
 
 https://quicksync.io/networks/kava.html
 
-Note that the current mainnet network is `kava_2222-10`. 
+Note that the current mainnet network is `kava_2222-10`.
 
 ### Syncing Your Node
 
@@ -141,7 +142,7 @@ This will give output like:
 }
 ```
 
-The main thing to watch is that the block height is increasing. Once you are caught up with the chain, `catching_up` will become false. At that point, you can start using your node to create a validator. 
+The main thing to watch is that the block height is increasing. Once you are caught up with the chain, `catching_up` will become false. At that point, you can start using your node to create a validator.
 
 To check the logs of the node:
 


### PR DESCRIPTION
## What Changed

- Updates docs with info about Kava 13 release and using the v0.23.0 binary