### PR TITLE
Update metamask.mdx

### DIFF
--- a/docs/ethereum/metamask.mdx
+++ b/docs/ethereum/metamask.mdx
@@ -13,7 +13,7 @@ To access Kava EVM, you'll first need to add Kava's network configuration in Met
 
 ### Mainnet
 
-- Network Name: Kava EVM Co-Chain
+- Network Name: Kava
 - New RPC URL: https://evm.kava.io
 - Chain ID: 2222
 - Currency Symbol: KAVA


### PR DESCRIPTION
changing chain name from Kava EVM Co-chian to "Kava"

## What Changes

- minor text change of name for chain documentation

## Why

Scott wanted to remove "EVM" from the name in the docs config info

## Feedback Requested

1. anything to be concerned about with this change?
