### PR TITLE
added Supra Oracle to Oracles folder in docs

### DIFF
--- a/docs/ethereum/Oracles/Supra.mdx
+++ b/docs/ethereum/Oracles/Supra.mdx
@@ -1,0 +1,14 @@
+---
+title: Supra
+---
+
+## Supra
+
+[Supra](https://supraoracles.com/) is a novel, high-throughput Oracle & IntraLayer: A vertically integrated toolkit of cross-chain solutions (data oracles, asset bridges, automation network, and more) that interlink all blockchains, public (L1s and L2s) or private (enterprises).
+
+Supra provides decentralized oracle price feeds that can be used for on-chain and off-chain use-cases such as spot and perpetual DEXes, lending protocols, and payments protocols. Supra’s oracle chain and consensus algorithm makes it the fastest-to-finality oracle provider, with layer-1 security guarantees. The pull oracle has a sub-second response time. Aside from speed and security, Supra’s rotating node architecture gathers data from 40+ data sources and applies a robust calculation methodology to get the most accurate value. The node provenance on the data dashboard also provides a fully transparent historical audit trail. Supra’s Distributed Oracle Agreement (DORA) paper was accepted into ICDCS 2023, oldest distributed systems conference.
+
+Check out our developer docs [here](https://supraoracles.com/docs).
+
+
+


### PR DESCRIPTION
## What Changes

- Added 'Supra.mdx' file in Oracles folder

## Why

Supra deployed oracle services to mainnet. We would like developers to easily access our documentation for integrations.

## Feedback Requested

Let me know if you have any questions.

